### PR TITLE
Pin kyverno so we don't automatically update to 3.x

### DIFF
--- a/pkg/cmd/updatecharts/charts.go
+++ b/pkg/cmd/updatecharts/charts.go
@@ -46,7 +46,7 @@ func UpdateCharts(ctx context.Context, only string) error {
 		if only != "" && name != only { // skip others if running for one chart
 			continue
 		}
-		if !chart.External { // skip non external charts
+		if !chart.External || chart.Pin { // skip non external and pinned charts
 			continue
 		}
 		fmt.Println("Checking chart:", name)

--- a/pkg/rconfig/sources.yaml
+++ b/pkg/rconfig/sources.yaml
@@ -22,6 +22,8 @@ kyverno:
   version: 2.7.3
   source: https://kyverno.github.io/kyverno/index.yaml
   external: true
+  # Kyverno is pinned to 2.7.x as WF does not support the application of v3.x policies yet
+  pin: true
 metrics-server:
   version: 3.12.1
   source: https://kubernetes-sigs.github.io/metrics-server/index.yaml

--- a/pkg/rconfig/types.go
+++ b/pkg/rconfig/types.go
@@ -20,4 +20,6 @@ type ChartConfig struct {
 	Source   string `json:"source,omitempty" yaml:"source,omitempty"`
 	External bool   `json:"external,omitempty" yaml:"external,omitempty"`
 	Values   []byte `json:"values,omitempty" yaml:"values,omitempty"`
+	// Pin indicates that we should not automatically update this dependency, manual updates only.
+	Pin bool `json:"pin,omitempty" yaml:"pin,omitempty"`
 }


### PR DESCRIPTION
At this time, we'll keep Kyverno at 2.7.x as Wayfinder needs to be updated to generate 3.x-compatible policies before we move that forward.