### PR TITLE
Fix dockerfile and charts URL override script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ SHELL = /bin/bash -e
 AUTHOR_EMAIL=wayfinder@appvia.io
 ROOT_DIR=${PWD}
 UNAME := $(shell uname)
+REGISTRY ?= quay.io
+REGISTRY_ORG ?= appvia-wf-dev
+VERSION ?= latest
 
 .PHONY: charts
 charts:
@@ -12,3 +15,8 @@ charts:
 update-charts:
 	@echo "--> Updating charts"
 	@go run ./cmd/updatecharts/ update-charts
+
+charts-image: charts
+	@echo "--> Building charts docker image ${REGISTRY}/${REGISTRY_ORG}/charts:${VERSION}"
+	docker build --platform amd64 -t ${REGISTRY}/${REGISTRY_ORG}/charts:${VERSION} -f charts-compiled/Dockerfile charts-compiled
+	docker push ${REGISTRY}/${REGISTRY_ORG}/charts:${VERSION}

--- a/charts/set-charts-url.sh
+++ b/charts/set-charts-url.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-CHARTS_URL="${CHARTS_PROTOCOL:-http}:\/\/${CHARTS_HOSTNAME}"
+CHARTS_URL="${CHARTS_PROTOCOL:-http}://${CHARTS_HOSTNAME}"
 
-sed s/https:\/\/charts\.wayfinder\.run/$CHARTS_URL/g /usr/share/nginx/html/index.yaml.tmpl > /usr/share/nginx/html/index.yaml
+sed s~https://charts.wayfinder.run~$CHARTS_URL~g /usr/share/nginx/html/index.yaml.tmpl > /usr/share/nginx/html/index.yaml


### PR DESCRIPTION
The URL replacement script did not function correctly due to incorrect regex escaping.

Also adds a make target to build and push the docker image.